### PR TITLE
Refactor module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ override.tf.json
 # !example_override.tf
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
+*tfplan*
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.50.0
+    rev: v1.72.0
     hooks:
       - id: terraform_fmt
+        verbose: true
       - id: terraform_docs

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,4 @@
+# https://terraform-docs.io/user-guide/configuration/
+
+settings:
+  hide-empty: true

--- a/README.md
+++ b/README.md
@@ -1,23 +1,51 @@
 # terraform-module-postgresql-flexible
-Terraform module for Azure PostgreSQL Flexible Server
+Terraform module for [Azure Database for PostgreSQL - Flexible Server](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/)
+
+## Example
+
+```hcl
+data "azurerm_subnet" "this" {
+  name                 = "postgresql"
+  resource_group_name  = "ss-${var.env}-network-rg"
+  virtual_network_name = "ss-${var.env}-vnet"
+}
+
+module "postgresql" {
+  source = "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"
+  env    = var.env
+
+  product   = var.product
+  component = var.component
+
+  pgsql_databases = [
+    {
+      name : "application"
+    }
+  ]
+  # TODO this will be removed in a follow-up
+  pgsql_delegated_subnet_id = data.azurerm_subnet.this.id
+  # Set your PostgreSQL version, note AzureAD auth requires version 12 (and not 11 or 13 currently)
+  pgsql_version             = "12"
+
+  common_tags = var.common_tags
+}
+```
 
 
-<!-- BEGIN_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 2.41.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.7.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 2.41.0 |
-
-## Modules
-
-No modules.
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.7.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.2.0 |
 
 ## Resources
 
@@ -27,33 +55,49 @@ No modules.
 | [azurerm_postgresql_flexible_server_configuration.pgsql_server_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_database.pg_databases](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
 | [azurerm_postgresql_flexible_server_firewall_rule.pg_firewall_rules](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_firewall_rule) | resource |
-| [azurerm_resource_group.automation_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [random_password.password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Common tag to be applied to resources. | `map(string)` | `{}` | no |
-| <a name="input_location"></a> [location](#input\_location) | Target Azure location to deploy the resource. | `string` | `"UK South"` | no |
-| <a name="input_pgsql_admin_password"></a> [pgsql\_admin\_password](#input\_pgsql\_admin\_password) | PGSql flexible server admin password. | `string` | `null` | no |
-| <a name="input_pgsql_admin_username"></a> [pgsql\_admin\_username](#input\_pgsql\_admin\_username) | PGSql flexible server admin username. | `string` | `"pgadmin"` | no |
-| <a name="input_pgsql_databases"></a> [pgsql\_databases](#input\_pgsql\_databases) | Databases for the pgsql instance. | `map(string)` | `null` | no |
-| <a name="input_pgsql_delegated_subnet_id"></a> [pgsql\_delegated\_subnet\_id](#input\_pgsql\_delegated\_subnet\_id) | PGSql delegated subnet id. | `string` | `null` | no |
-| <a name="input_pgsql_firewall_rules"></a> [pgsql\_firewall\_rules](#input\_pgsql\_firewall\_rules) | PGSql firewall rules. | `map(string)` | `{}` | no |
-| <a name="input_pgsql_private_dns_zone_id"></a> [pgsql\_private\_dns\_zone\_id](#input\_pgsql\_private\_dns\_zone\_id) | PGSql private dns zone id. | `string` | `null` | no |
-| <a name="input_pgsql_server_configuration"></a> [pgsql\_server\_configuration](#input\_pgsql\_server\_configuration) | The PGSql configuration. | `map(string)` | <pre>{<br>  "name": "backslash_quote",<br>  "value": "on"<br>}</pre> | no |
-| <a name="input_pgsql_server_name"></a> [pgsql\_server\_name](#input\_pgsql\_server\_name) | The pgsql flexible server instance name. | `string` | `null` | no |
-| <a name="input_pgsql_server_zone"></a> [pgsql\_server\_zone](#input\_pgsql\_server\_zone) | Specifies the Availability Zone in which the PGSql Flexible Server should be located. | `string` | `"1"` | no |
-| <a name="input_pgsql_sku"></a> [pgsql\_sku](#input\_pgsql\_sku) | The PGSql flexible server instance sku. | `string` | `"Standard_D2s_v3"` | no |
-| <a name="input_pgsql_storage_mb"></a> [pgsql\_storage\_mb](#input\_pgsql\_storage\_mb) | Max storage allowed for the PGSql Flexibile instance. | `number` | `65536` | no |
-| <a name="input_pgsql_version"></a> [pgsql\_version](#input\_pgsql\_version) | The PGSql flexible server instance version. | `string` | `"12"` | no |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Enter Resource Group name. | `string` | `null` | no |
+| <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Common tag to be applied to resources. | `map(string)` | n/a | yes |
+| <a name="input_component"></a> [component](#input\_component) | https://hmcts.github.io/glossary/#component | `string` | n/a | yes |
+| <a name="input_env"></a> [env](#input\_env) | Environment value. | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Target Azure location to deploy the resource | `string` | `"UK South"` | no |
+| <a name="input_name"></a> [name](#input\_name) | The default name will be product+component+env, you can override the product+component part by setting this | `string` | `""` | no |
+| <a name="input_pgsql_admin_username"></a> [pgsql\_admin\_username](#input\_pgsql\_admin\_username) | Admin username | `string` | `"pgadmin"` | no |
+| <a name="input_pgsql_databases"></a> [pgsql\_databases](#input\_pgsql\_databases) | Databases for the pgsql instance. | `list(object({ name : string, collation : optional(string), charset : optional(string) }))` | n/a | yes |
+| <a name="input_pgsql_delegated_subnet_id"></a> [pgsql\_delegated\_subnet\_id](#input\_pgsql\_delegated\_subnet\_id) | PGSql delegated subnet id. | `string` | n/a | yes |
+| <a name="input_pgsql_firewall_rules"></a> [pgsql\_firewall\_rules](#input\_pgsql\_firewall\_rules) | Postgres firewall rules | `list(object({ name : string, start_ip_address : string, end_ip_address : string }))` | `[]` | no |
+| <a name="input_pgsql_server_configuration"></a> [pgsql\_server\_configuration](#input\_pgsql\_server\_configuration) | Postgres server configuration | `list(object({ name : string, value : string }))` | <pre>[<br>  {<br>    "name": "backslash_quote",<br>    "value": "on"<br>  }<br>]</pre> | no |
+| <a name="input_pgsql_sku"></a> [pgsql\_sku](#input\_pgsql\_sku) | The PGSql flexible server instance sku | `string` | `"GP_Standard_D2s_v3"` | no |
+| <a name="input_pgsql_storage_mb"></a> [pgsql\_storage\_mb](#input\_pgsql\_storage\_mb) | Max storage allowed for the PGSql Flexibile instance | `number` | `65536` | no |
+| <a name="input_pgsql_version"></a> [pgsql\_version](#input\_pgsql\_version) | The PGSql flexible server instance version. | `string` | n/a | yes |
+| <a name="input_product"></a> [product](#input\_product) | https://hmcts.github.io/glossary/#product | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_password"></a> [password](#output\_password) | n/a |
 | <a name="output_resource_group_location"></a> [resource\_group\_location](#output\_resource\_group\_location) | n/a |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | n/a |
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Contributing
+
+We use pre-commit hooks for validating the terraform format and maintaining the documentation automatically.
+Install it with:
+
+```shell
+$ brew install pre-commit terraform-docs
+$ pre-commit install
+```
+
+If you add a new hook make sure to run it against all files:
+```shell
+$ pre-commit run --all-files
+```

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,0 +1,32 @@
+data "azurerm_subnet" "this" {
+  name                 = "postgresql"
+  resource_group_name  = "ss-${var.env}-network-rg"
+  virtual_network_name = "ss-${var.env}-vnet"
+}
+
+module "postgresql" {
+  source = "../"
+  env    = var.env
+
+  product   = "platops"
+  component = "example"
+
+  common_tags = module.common_tags.common_tags
+  pgsql_databases = [
+    {
+      name : "application"
+    }
+  ]
+  pgsql_delegated_subnet_id = data.azurerm_subnet.this.id
+  pgsql_version             = "12"
+}
+
+# only for use when building from ADO and as a quick example to get valid tags
+# if you are building from Jenkins use `var.common_tags` provided by the pipeline
+module "common_tags" {
+  source = "git@github.com:hmcts/terraform-module-common-tags?ref=master"
+
+  builtFrom   = "hmcts/terraform-module-postgresql-flexible"
+  environment = var.env
+  product     = "sds-platform"
+}

--- a/example/provider.tf
+++ b/example/provider.tf
@@ -1,0 +1,3 @@
+provider "azurerm" {
+  features {}
+}

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -1,0 +1,3 @@
+variable "env" {
+  default = "test"
+}

--- a/init.tf
+++ b/init.tf
@@ -1,20 +1,13 @@
 terraform {
   required_providers {
     azurerm = {
-      source                = "hashicorp/azurerm"
-      version               = ">= 2.41.0"
-      configuration_aliases = [azurerm.data]
+      source  = "hashicorp/azurerm"
+      version = ">= 3.7.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.2.0"
     }
   }
-}
-
-provider "azurerm" {
-  features {}
-  skip_provider_registration = true
-}
-
-provider "azurerm" {
-  alias = "data"
-  features {}
-  subscription_id = var.data_subscription
+  experiments = [module_variable_optional_attrs]
 }

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -1,56 +1,43 @@
 variable "location" {
-  description = "Target Azure location to deploy the resource."
+  description = "Target Azure location to deploy the resource"
   type        = string
   default     = "UK South"
 }
 
-variable "common_tags" {
-  description = "Common tag to be applied to resources."
-  type        = map(string)
-  default     = {}
-}
-
 variable "pgsql_admin_username" {
-  description = "PGSql flexible server admin username."
+  description = "Admin username"
   type        = string
   default     = "pgadmin"
 }
 
-variable "pgsql_version" {
-  description = "The PGSql flexible server instance version."
-  type        = string
-  default     = "13"
-}
-
 variable "pgsql_sku" {
-  description = "The PGSql flexible server instance sku."
+  description = "The PGSql flexible server instance sku"
   type        = string
-  default     = "Standard_D2s_v3"
+  default     = "GP_Standard_D2s_v3"
 }
 
 variable "pgsql_storage_mb" {
-  description = "Max storage allowed for the PGSql Flexibile instance."
+  description = "Max storage allowed for the PGSql Flexibile instance"
   type        = number
   default     = 65536
 }
 
-variable "pgsql_server_zone" {
-  description = "Specifies the Availability Zone in which the PGSql Flexible Server should be located."
-  type        = string
-  default     = "1"
-}
-
 variable "pgsql_server_configuration" {
-  description = "The PGSql configuration."
-  type        = map(string)
-  default = {
+  description = "Postgres server configuration"
+  type        = list(object({ name : string, value : string }))
+  default = [{
     name  = "backslash_quote"
     value = "on"
-  }
+  }]
 }
 
 variable "pgsql_firewall_rules" {
-  description = "PGSql firewall rules."
-  type        = map(string)
-  default     = {}
+  description = "Postgres firewall rules"
+  type        = list(object({ name : string, start_ip_address : string, end_ip_address : string }))
+  default     = []
+}
+
+variable "name" {
+  default     = ""
+  description = "The default name will be product+component+env, you can override the product+component part by setting this"
 }

--- a/inputs-required.tf
+++ b/inputs-required.tf
@@ -1,39 +1,34 @@
-variable "resource_group_name" {
-  description = "Enter Resource Group name."
-  type        = string
-  default     = null
-}
-
 variable "env" {
   description = "Environment value."
+  type        = string
 }
 
-variable "pgsql_server_name" {
-  description = "The pgsql flexible server instance name."
-  type        = string
-  default     = null
+variable "common_tags" {
+  description = "Common tag to be applied to resources."
+  type        = map(string)
 }
 
 variable "pgsql_databases" {
   description = "Databases for the pgsql instance."
-  type        = map(string)
-  default     = null
-}
-
-variable "pgsql_admin_password" {
-  description = "PGSql flexible server admin password."
-  type        = string
-  default     = null
+  type        = list(object({ name : string, collation : optional(string), charset : optional(string) }))
 }
 
 variable "pgsql_delegated_subnet_id" {
   description = "PGSql delegated subnet id."
   type        = string
-  default     = null
 }
 
-variable "pgsql_private_dns_zone_id" {
-  description = "PGSql private dns zone id."
+variable "pgsql_version" {
+  description = "The PGSql flexible server instance version."
   type        = string
-  default     = null
+}
+
+variable "product" {
+  description = "https://hmcts.github.io/glossary/#product"
+  type        = string
+}
+
+variable "component" {
+  description = "https://hmcts.github.io/glossary/#component"
+  type        = string
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,11 @@
 output "resource_group_name" {
-  value = azurerm_resource_group.automation_resource_group.name
+  value = azurerm_resource_group.rg.name
 }
 
 output "resource_group_location" {
-  value = azurerm_resource_group.automation_resource_group.name
+  value = azurerm_resource_group.rg.name
+}
+
+output "password" {
+  value = azurerm_postgresql_flexible_server.pgsql_server.administrator_password
 }

--- a/pgsql-flexible-server-db.tf
+++ b/pgsql-flexible-server-db.tf
@@ -1,8 +1,11 @@
 resource "azurerm_postgresql_flexible_server_database" "pg_databases" {
-  for_each = var.pgsql_databases
+  for_each = {
+    for index, db in var.pgsql_databases :
+    db.name => db
+  }
 
   name      = each.value.name
   server_id = azurerm_postgresql_flexible_server.pgsql_server.id
-  collation = each.value.collation
-  charset   = each.value.charset
+  collation = try(each.value.collation, null)
+  charset   = try(each.value.charset, null)
 }

--- a/pgsql-flexible-server-firewall.tf
+++ b/pgsql-flexible-server-firewall.tf
@@ -1,5 +1,8 @@
 resource "azurerm_postgresql_flexible_server_firewall_rule" "pg_firewall_rules" {
-  for_each = var.pgsql_firewall_rules
+  for_each = {
+    for index, rule in var.pgsql_firewall_rules :
+    rule.name => rule
+  }
 
   name             = each.value.name
   server_id        = azurerm_postgresql_flexible_server.pgsql_server.id

--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -1,25 +1,52 @@
+locals {
+  default_name = var.component != "" ? "${var.product}-${var.component}" : var.product
+  name         = var.name != "" ? var.name : local.default_name
+  server_name  = "${local.name}-${var.env}"
+
+  private_dns_zone_id = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/private.postgres.database.azure.com"
+}
+
+resource "random_password" "password" {
+  length = 20
+  # safer set of special characters for pasting in the shell
+  override_special = "()-_"
+}
+
 resource "azurerm_postgresql_flexible_server" "pgsql_server" {
-  name                = var.pgsql_server_name
-  resource_group_name = var.resource_group_name
+  name                = local.server_name
+  resource_group_name = azurerm_resource_group.rg.name
   location            = var.location
   version             = var.pgsql_version
 
   delegated_subnet_id = var.pgsql_delegated_subnet_id
-  private_dns_zone_id = var.pgsql_private_dns_zone_id
+  private_dns_zone_id = local.private_dns_zone_id
 
   administrator_login    = var.pgsql_admin_username
-  administrator_password = var.pgsql_admin_password
-  zone                   = var.pgsql_server_zone
+  administrator_password = random_password.password.result
 
   storage_mb = var.pgsql_storage_mb
 
   sku_name = var.pgsql_sku
 
-  common_tags = var.common_tags
+  tags = var.common_tags
+
+  high_availability {
+    mode = "ZoneRedundant"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      zone,
+      high_availability.0.standby_availability_zone,
+    ]
+  }
 }
 
 resource "azurerm_postgresql_flexible_server_configuration" "pgsql_server_config" {
-  for_each = var.pgsql_server_configuration
+  for_each = {
+    for index, config in var.pgsql_server_configuration :
+    config.name => config
+  }
 
   name      = each.value.name
   server_id = azurerm_postgresql_flexible_server.pgsql_server.id

--- a/resource-group.tf
+++ b/resource-group.tf
@@ -1,6 +1,6 @@
-resource "azurerm_resource_group" "automation_resource_group" {
+resource "azurerm_resource_group" "rg" {
+  name     = "${local.name}-data-${var.env}"
   location = var.location
-  name     = var.resource_group_name
 
   tags = var.common_tags
 }


### PR DESCRIPTION
Applies the following principles:

- Convention over configuration
  - Use product and component variables for naming
  - Resource groups consistently named by not allowing overriding
  - Use sensible charsets and collation by default, don't force users to specify
- High availability built-in by default
- Never expect a user to provide a private DNS zone
  - We can't link multiple DNS zones to the VPN so we always deploy a central one (recent services seem to allow you to supply your own named one but we shouldn't need that)
- Add an example to the README
- Don't default postgres versions
  - You can never update it once you add it as it's a breaking change and teams could accidentally have terraform try recreate it, just force people to specify it and document the current recommended version in the README
