### PR TITLE
Db maintenance window

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ module "postgresql" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_user_object_id"></a> [admin\_user\_object\_id](#input\_admin\_user\_object\_id) | The ID of the principal to be granted admin access to the database server, should be the principal running this normally | `any` | `null` | no |
-| <a name="input_backup_retention_days"></a> [backup\_retention\_days](#input\_backup\_retention\_days) | Backup retention period in days for the PGSql instance. Valid values are between 7 & 35 days | `number` | `7` | no |
+| <a name="input_backup_retention_days"></a> [backup\_retention\_days](#input\_backup\_retention\_days) | Backup retention period in days for the PGSql instance. Valid values are between 7 & 35 days | `number` | `35` | no |
 | <a name="input_business_area"></a> [business\_area](#input\_business\_area) | business\_area name - sds or cft. | `any` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Common tag to be applied to resources. | `map(string)` | n/a | yes |
 | <a name="input_component"></a> [component](#input\_component) | https://hmcts.github.io/glossary/#component | `string` | n/a | yes |

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -49,7 +49,7 @@ variable "name" {
 }
 
 variable "backup_retention_days" {
-  default     = 7
+  default     = 35
   description = "Backup retention period in days for the PGSql instance. Valid values are between 7 & 35 days"
 }
 

--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -72,6 +72,12 @@ resource "azurerm_postgresql_flexible_server" "pgsql_server" {
     mode = "ZoneRedundant"
   }
 
+maintenance_window {
+    day_of_week  = "0"
+    start_hour   = "03"
+    start_minute = "00"
+  }
+
   lifecycle {
     ignore_changes = [
       zone,

--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -72,7 +72,7 @@ resource "azurerm_postgresql_flexible_server" "pgsql_server" {
     mode = "ZoneRedundant"
   }
 
-maintenance_window {
+  maintenance_window {
     day_of_week  = "0"
     start_hour   = "03"
     start_minute = "00"


### PR DESCRIPTION
### Change description ###
Avoid teams getting caught out by Azure's system maintenance window downtime. We are creating a custom time of Sunday 3AM. This only applies to Flexible Server.
Extending backups to 35 days to keep in line with CNP Single Server module


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
