### PR TITLE
Add flag to allow creation of SDP read user on database

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ variable "aks_subscription_id" {} # provided by the Jenkins library, ADO users w
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_add_sdp_read_user"></a> [add\_sdp\_read\ user](#input\_add\_sdp\_read\_user) | Add a read-only user for SDP to use for analytics. Defaults to false. | `bool` | `false` | no |
+| <a name="input_add_sdp_read_user"></a> [add\_sdp\_read\_user](#input\_add\_sdp\_read\_user) | Add a read-only user for SDP to use for analytics. Defaults to false. | `bool` | `false` | no |
 | <a name="input_admin_user_object_id"></a> [admin\_user\_object\_id](#input\_admin\_user\_object\_id) | The ID of the principal to be granted admin access to the database server, should be the principal running this normally. If you are using Jenkins pass through the variable 'jenkins\_AAD\_objectId'. | `any` | `null` | no |
 | <a name="input_backup_retention_days"></a> [backup\_retention\_days](#input\_backup\_retention\_days) | Backup retention period in days for the PGSql instance. Valid values are between 7 & 35 days | `number` | `35` | no |
 | <a name="input_business_area"></a> [business\_area](#input\_business\_area) | business\_area name - sds or cft. | `any` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ variable "aks_subscription_id" {} # provided by the Jenkins library, ADO users w
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_add_sdp_read_user"></a> [add\_sdp\_read\ user](#input\_add\_sdp\_read\_user) | Add a read-only user for SDP to use for analytics. Defaults to false. | `bool` | `false` | no |
 | <a name="input_admin_user_object_id"></a> [admin\_user\_object\_id](#input\_admin\_user\_object\_id) | The ID of the principal to be granted admin access to the database server, should be the principal running this normally. If you are using Jenkins pass through the variable 'jenkins\_AAD\_objectId'. | `any` | `null` | no |
 | <a name="input_backup_retention_days"></a> [backup\_retention\_days](#input\_backup\_retention\_days) | Backup retention period in days for the PGSql instance. Valid values are between 7 & 35 days | `number` | `35` | no |
 | <a name="input_business_area"></a> [business\_area](#input\_business\_area) | business\_area name - sds or cft. | `any` | n/a | yes |

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -107,3 +107,9 @@ variable "public_access" {
   default     = false
   description = "Specifies whether or not public access is allowed for this PostgreSQL Flexible Server. Defaults to false."
 }
+
+variable "add_sdp_read_user" {
+  type        = bool
+  default     = false
+  description = "Add a read-only user for SDP to use for analytics. Defaults to false."
+}


### PR DESCRIPTION
Changes:

Add a add_sdp_read_user property on the module. Defaults to false but if set to true will:

Create random password for SDP read user.
If add_sdp_read_user is set then also add password to mi-vault for the mapped environment.
Creates the SDP read user via the set postgres permissions script. This script will now also trigger when the add_sdp_read_user flag changes or the sdp read username changes.