### PR TITLE
DTSPO-15564 Mark DB_PASSWORD as nonsensitive so that script output can be seen

### DIFF
--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -156,7 +156,7 @@ resource "null_resource" "set-user-permissions-additionaldbs" {
       DB_READER_USER = local.db_reader_user
       DB_NAME        = each.value.name
       DB_ADMIN       = azurerm_postgresql_flexible_server.pgsql_server.administrator_login
-      DB_PASSWORD    = azurerm_postgresql_flexible_server.pgsql_server.administrator_password
+      DB_PASSWORD    = nonsensitive(azurerm_postgresql_flexible_server.pgsql_server.administrator_password)
     }
   }
   depends_on = [


### PR DESCRIPTION
see https://github.com/hashicorp/terraform/issues/27154#issuecomment-1070983147

Masking this means we have no idea what output happened in the script which makes debugging difficult