### PR TITLE
DTSPO-15564 Grant access to databases for admin users

### DIFF
--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -151,8 +151,9 @@ resource "null_resource" "set-user-permissions-additionaldbs" {
     command = "${path.module}/set-postgres-permissions.bash"
 
     environment = {
-      DB_HOST_NAME   = azurerm_postgresql_flexible_server.pgsql_server.fqdn
+      PGHOST   = azurerm_postgresql_flexible_server.pgsql_server.fqdn
       DB_USER        = data.azuread_service_principal.mi_name[0].display_name
+      DB_ADMIN_GROUP = local.admin_group
       DB_READER_USER = local.db_reader_user
       DB_NAME        = each.value.name
       DB_ADMIN       = azurerm_postgresql_flexible_server.pgsql_server.administrator_login

--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -151,7 +151,7 @@ resource "null_resource" "set-user-permissions-additionaldbs" {
     command = "${path.module}/set-postgres-permissions.bash"
 
     environment = {
-      PGHOST   = azurerm_postgresql_flexible_server.pgsql_server.fqdn
+      PGHOST         = azurerm_postgresql_flexible_server.pgsql_server.fqdn
       DB_USER        = data.azuread_service_principal.mi_name[0].display_name
       DB_ADMIN_GROUP = local.admin_group
       DB_READER_USER = local.db_reader_user

--- a/set-postgres-permissions.bash
+++ b/set-postgres-permissions.bash
@@ -66,5 +66,7 @@ GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"${DB_READER_USER}\";
 
 "
 set -x
-psql "sslmode=require host=${DB_HOST_NAME} port=5432 dbname=${DB_NAME} user=${DB_USER}" -c "${SQL_COMMAND}"
+export PGDATABASE="${DB_NAME}"
+export PGUSER="${DB_USER}"
+psql -c "${SQL_COMMAND}"
 set +x

--- a/set-postgres-permissions.bash
+++ b/set-postgres-permissions.bash
@@ -1,27 +1,10 @@
 #!/usr/bin/env bash
 
+export PGPORT=5432
 export AZURE_CONFIG_DIR=~/.azure-db-manager
 az login --identity
 
-# shellcheck disable=SC2155
-
-SQL_COMMAND_POSTGRES="
-DO
-\$do\$
-BEGIN
-   IF NOT EXISTS (
-      SELECT FROM pg_catalog.pg_roles  -- SELECT list can be empty for this
-      WHERE rolname = '${DB_READER_USER}') THEN
-
-      PERFORM pgaadauth_create_principal('${DB_READER_USER}', false, false);
-      
-   END IF;
-END
-\$do\$;
-
-"
-
-## Delay until DB DNS and propagated 
+## Delay until DB DNS and propagated
 COUNT=0;
 MAX=10;
 while true; do
@@ -41,16 +24,37 @@ export PGPASSWORD=$DB_PASSWORD
 
 JENKINS_SQL_COMMAND="
 GRANT ALL ON ALL TABLES IN SCHEMA public TO \"${DB_USER}\";
+GRANT ${DB_ADMIN} to \"${DB_USER}\";
+GRANT ${DB_ADMIN} to \"${DB_ADMIN_GROUP}\";
 "
 
 set -x
-psql "sslmode=require host=${DB_HOST_NAME} port=5432 dbname=${DB_NAME} user=${DB_ADMIN}" -c "${JENKINS_SQL_COMMAND}"
+export PGDATABASE="${DB_NAME}"
+export PGUSER="${DB_ADMIN}"
+psql -c "${JENKINS_SQL_COMMAND}"
 set +x
 
 export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv)
 
+SQL_COMMAND_POSTGRES="
+DO
+\$do\$
+BEGIN
+   IF NOT EXISTS (
+      SELECT FROM pg_catalog.pg_roles  -- SELECT list can be empty for this
+      WHERE rolname = '${DB_READER_USER}') THEN
+
+      PERFORM pgaadauth_create_principal('${DB_READER_USER}', false, false);
+
+   END IF;
+END
+\$do\$;
+"
+
 set -x
-psql "sslmode=require host=${DB_HOST_NAME} port=5432 dbname=postgres user=${DB_USER}" -c "${SQL_COMMAND_POSTGRES}"
+export PGDATABASE="postgres"
+export PGUSER="${DB_USER}"
+psql -c "${SQL_COMMAND_POSTGRES}"
 set +x
 
 SQL_COMMAND="


### PR DESCRIPTION
Also will fix read only users on at least migrated databases as the admin users didn't have the ability to grant to read only users before in databases outside of postgres.

I assume this works for brand new DBs as-is but migrated databases permissions don't seem to work without this

Tested on Pip with Chris Stacey