### PR TITLE
Block v5 sku as no reservations available

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Terraform module for [Azure Database for PostgreSQL - Flexible Server](https://d
 ## Example
 
 provider.tf
-```hcl
+```terraform
 provider "azurerm" {
   features {}
 }
@@ -18,7 +18,7 @@ provider "azurerm" {
 ```
 
 postgres.tf
-```hcl
+```terraform
 module "postgresql" {
 
   providers = {
@@ -41,6 +41,7 @@ module "postgresql" {
     }
   ]
 
+  pgsql_sku     = "GP_Standard_D2ds_v4"
   pgsql_version = "15"
   
   # The ID of the principal to be granted admin access to the database server.

--- a/example/main.tf
+++ b/example/main.tf
@@ -13,6 +13,8 @@ module "postgresql" {
 
   subnet_suffix = "expanded"
 
+  enable_read_only_group_access = false
+
   common_tags = module.common_tags.common_tags
   pgsql_databases = [
     {

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -3,5 +3,5 @@ variable "env" {
 }
 
 variable "aks_subscription_id" {
-  default = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  default = "3eec5bde-7feb-4566-bfb6-805df6e10b90"
 }

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -20,6 +20,14 @@ variable "pgsql_sku" {
   description = "The PGSql flexible server instance sku"
   type        = string
   default     = "GP_Standard_D2s_v3"
+
+  validation {
+    condition = can(regex(".+(_v3|_v4)$", var.pgsql_sku))
+    # because v5 doesn't currently support reservations, if they are supported in the future this restriction should be removed
+    # see https://azure.microsoft.com/en-gb/pricing/details/postgresql/flexible-server/
+    # search Ddsv5 and Edsv5
+    error_message = "The pgsql_sku value must use either a v3 or a v4 SKU."
+  }
 }
 
 variable "pgsql_storage_mb" {


### PR DESCRIPTION
### Change description ###

40% discount available for other SKUs:
https://azure.microsoft.com/en-gb/pricing/details/postgresql/flexible-server/

From testing:

```
❯ terraform plan
╷
│ Error: Invalid value for variable
│
│   on main.tf line 18, in module "postgresql":
│   18:   pgsql_sku = "GP_Standard_D2ds_v5"
│     ├────────────────
│     │ var.pgsql_sku is "GP_Standard_D2ds_v5"
│
│ The pgsql_sku value must use either a v3 or a v4 SKU.
│
│ This was checked by the validation rule at ../inputs-optional.tf:24,3-13.
```

also tested with v3 and v4


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
