### PR TITLE
Update to accept burstable skus

### DIFF
--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -22,7 +22,7 @@ variable "pgsql_sku" {
   default     = "GP_Standard_D2s_v3"
 
   validation {
-    condition = can(regex(".+(_v3|_v4|B_.*$)", var.pgsql_sku))
+    condition = can(regex(".*(_v3|_v4|^B_.*$).*", var.pgsql_sku))
     # because v5 doesn't currently support reservations, if they are supported in the future this restriction should be removed
     # see https://azure.microsoft.com/en-gb/pricing/details/postgresql/flexible-server/
     # search Ddsv5 and Edsv5

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -22,11 +22,11 @@ variable "pgsql_sku" {
   default     = "GP_Standard_D2s_v3"
 
   validation {
-    condition = can(regex(".+(_v3|_v4)$", var.pgsql_sku))
+    condition = can(regex(".+(_v3|_v4|B_.*$)", var.pgsql_sku))
     # because v5 doesn't currently support reservations, if they are supported in the future this restriction should be removed
     # see https://azure.microsoft.com/en-gb/pricing/details/postgresql/flexible-server/
     # search Ddsv5 and Edsv5
-    error_message = "The pgsql_sku value must use either a v3 or a v4 SKU."
+    error_message = "The pgsql_sku value must use either a v3, v4 or Burstable SKU."
   }
 }
 


### PR DESCRIPTION
This validation is in place to stop v5 skus but also stopped burstable sku, this update will allow those that begin with B_ as well

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
