### PR TITLE
Change high availability var to actually be an override

### DIFF
--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -106,7 +106,7 @@ variable "charset" {
 
 variable "high_availability" {
   type        = bool
-  default     = false
+  default     = null
   description = "Overrides the automatic selection of high availability mode for the PostgreSQL Flexible Server. Generally you shouldn't set this yourself."
 }
 

--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -18,7 +18,7 @@ locals {
 
 
   high_availability_environments = ["ptl", "perftest", "stg", "aat", "prod"]
-  high_availability              = var.high_availability == true || contains(local.high_availability_environments, local.env)
+  high_availability              = var.high_availability == null ? contains(local.high_availability_environments, local.env) : var.high_availability
 
   subnet_name = var.subnet_suffix != null ? "postgres-${var.subnet_suffix}" : "postgresql"
 


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###

The `high_availability` variable for the postgres flexible server is described as:

> "Overrides the automatic selection of high availability mode for the PostgreSQL Flexible Server. Generally you shouldn't set this yourself."

However the current implementation is not actually an override, but rather an OR condition against the default setting for the given environment, meaning it cannot be used to switch high availability OFF. This functionality is important for replica databases, for which high availability is not supported at all.

This **IS** technically a breaking change, however seeing as the only team using this feature are [camunda](https://github.com/hmcts/camunda-bpm/blob/f552be071c6be9616d24234ed4d9f8f02f39a8fa/infrastructure/db.tf#L17) who are not only referencing their own branch of this module but also only using the option to enable HA in perftest, merging this to master will have no impact on anybody.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
