### PR TITLE
as of AzureRM Provider 3.105.0 the property `public_network_access_en…

### DIFF
--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -59,6 +59,7 @@ resource "azurerm_postgresql_flexible_server" "pgsql_server" {
   resource_group_name = local.postgresql_rg_name
   location            = local.postgresql_rg_location
   version             = var.pgsql_version
+  public_network_access_enabled = var.public_access
 
   create_mode                       = var.create_mode
   point_in_time_restore_time_in_utc = var.restore_time


### PR DESCRIPTION


### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17844

### Change description ###
as of AzureRM Provider 3.105.0 the property `public_network_access_enabled` needs to be set explicitly 
https://github.com/hashicorp/terraform-provider-azurerm/issues/26098

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

