### PR TITLE
Update: Stop data source dependency causing rebuilds

### DIFF
--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -133,7 +133,7 @@ resource "azurerm_postgresql_flexible_server_active_directory_administrator" "pg
   server_name         = azurerm_postgresql_flexible_server.pgsql_server.name
   resource_group_name = azurerm_postgresql_flexible_server.pgsql_server.resource_group_name
   tenant_id           = data.azurerm_client_config.current.tenant_id
-  object_id           = data.azuread_group.db_admin.object_id
+  object_id           = local.is_prod ? "4d0554dd-fe60-424a-be9c-36636826d927" : "e7ea2042-4ced-45dd-8ae3-e051c6551789"
   principal_name      = local.admin_group
   principal_type      = "Group"
   depends_on = [


### PR DESCRIPTION
There is some weird behaviour where the ID of a data resource is not known until after an apply, but other resources are using this id directly. The result is recreation of resources even though nothing is changing

Trying this to skip out the middle man and see what the plan is saying