### PR TITLE
DTSPO-25133: Updating DTS PlatOps Postgres admin groups to new admin groups

### DIFF
--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -13,7 +13,7 @@ locals {
 
   is_prod = length(regexall(".*(prod).*", var.env)) > 0
 
-  admin_group     = local.is_prod ? "PlatOps PostgreSQL Admin Access SC" : "PlatOps PostgreSQL Admin Access"
+  admin_group     = local.is_prod ? "DTS Platform Operations PostgreSQL Admin Access SC" : "DTS Platform Operations PostgreSQL Admin Access"
   db_report_group = "DTS Production DB Reporting"
   db_reader_user  = local.is_prod ? "DTS JIT Access ${var.product} DB Reader SC" : "DTS ${upper(var.business_area)} DB Access Reader"
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25133

### Change description

- Updating "DTS Platform Operations" and "DTS Platform Operations SC" to "PlatOps PostgreSQL Admin Access" and "PlatOps PostgreSQL Admin Access SC"
- "PlatOps PostgreSQL Admin Access" and "PlatOps PostgreSQL Admin Access SC" have been added as new groups in Entra and PlatOps members can add themselves through My Access

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
