### PR TITLE
Guard PostgreSQL flexible server destruction

### DIFF
--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -119,6 +119,7 @@ resource "azurerm_postgresql_flexible_server" "pgsql_server" {
   }
 
   lifecycle {
+    prevent_destroy = true
     ignore_changes = [
       zone,
       high_availability.0.standby_availability_zone,


### PR DESCRIPTION
Adds lifecycle protection to the PostgreSQL flexible server resource so Terraform fails instead of destroying or replacing the server. Intentional replacement now requires explicitly removing the guard first.