### PR TITLE
Avoid storage shrink plans with auto-grow

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ force_db_report_privileges_trigger = "1"
 | <a name="input_alert_frequency"></a> [alert\_frequency](#input\_alert\_frequency) | The frequency of the alert check. | `string` | `"PT5M"` | no |
 | <a name="input_alert_severity"></a> [alert\_severity](#input\_alert\_severity) | The severity level of the alert (1=Critical, 2=Warning ...). | `number` | `1` | no |
 | <a name="input_alert_window_size"></a> [alert\_window\_size](#input\_alert\_window\_size) | The period over which the metric is evaluated. | `string` | `"PT15M"` | no |
-| <a name="input_auto_grow_enabled"></a> [auto\_grow\_enabled](#input\_auto\_grow\_enabled) | Specifies whether the storage auto grow for PostgreSQL Flexible Server is enabled? Defaults to false. | `bool` | `false` | no |
+| <a name="input_auto_grow_enabled"></a> [auto\_grow\_enabled](#input\_auto\_grow\_enabled) | Specifies whether the storage auto grow for PostgreSQL Flexible Server is enabled. | `bool` | `false` | no |
 | <a name="input_backup_policy_id"></a> [backup\_policy\_id](#input\_backup\_policy\_id) | Resource ID of the backup policy within the backup vault. | `string` | `"/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/mgmt-infra-prod-rg/providers/Microsoft.DataProtection/backupVaults/cnp-backup-vault/backupPolicies/postgresql-crit4-5"` | no |
 | <a name="input_backup_retention_days"></a> [backup\_retention\_days](#input\_backup\_retention\_days) | Backup retention period in days for the PGSql instance. Valid values are between 7 & 35 days | `number` | `35` | no |
 | <a name="input_backup_vault_id"></a> [backup\_vault\_id](#input\_backup\_vault\_id) | Resource ID of the Azure Data Protection Backup Vault. | `string` | `"/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/mgmt-infra-prod-rg/providers/Microsoft.DataProtection/backupVaults/cnp-backup-vault"` | no |
@@ -420,7 +420,7 @@ force_db_report_privileges_trigger = "1"
 | <a name="input_pgsql_firewall_rules"></a> [pgsql\_firewall\_rules](#input\_pgsql\_firewall\_rules) | Postgres firewall rules | `list(object({ name : string, start_ip_address : string, end_ip_address : string }))` | `[]` | no |
 | <a name="input_pgsql_server_configuration"></a> [pgsql\_server\_configuration](#input\_pgsql\_server\_configuration) | Postgres server configuration | `list(object({ name : string, value : string }))` | <pre>[<br/>  {<br/>    "name": "backslash_quote",<br/>    "value": "on"<br/>  }<br/>]</pre> | no |
 | <a name="input_pgsql_sku"></a> [pgsql\_sku](#input\_pgsql\_sku) | The PGSql flexible server instance sku | `string` | `"GP_Standard_D2s_v3"` | no |
-| <a name="input_pgsql_storage_mb"></a> [pgsql\_storage\_mb](#input\_pgsql\_storage\_mb) | Max storage allowed for the PGSql Flexibile instance | `number` | `65536` | no |
+| <a name="input_pgsql_storage_mb"></a> [pgsql\_storage\_mb](#input\_pgsql\_storage\_mb) | Storage size for the PGSql Flexible instance. Used when the server is created, then ignored to avoid shrink plans after Azure auto-grows storage. | `number` | `65536` | no |
 | <a name="input_pgsql_storage_tier"></a> [pgsql\_storage\_tier](#input\_pgsql\_storage\_tier) | The storage tier, this should be left as null but may need to be overriden to allow increased storage. | `string` | `null` | no |
 | <a name="input_pgsql_version"></a> [pgsql\_version](#input\_pgsql\_version) | The PGSql flexible server instance version. | `string` | n/a | yes |
 | <a name="input_product"></a> [product](#input\_product) | https://hmcts.github.io/glossary/#product | `string` | n/a | yes |

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -23,7 +23,7 @@ variable "pgsql_sku" {
 }
 
 variable "pgsql_storage_mb" {
-  description = "Max storage allowed for the PGSql Flexibile instance"
+  description = "Storage size for the PGSql Flexible instance. Used when the server is created, then ignored to avoid shrink plans after Azure auto-grows storage."
   type        = number
   default     = 65536
 }
@@ -165,7 +165,7 @@ variable "subnet_suffix" {
 variable "auto_grow_enabled" {
   type        = bool
   default     = false
-  description = "Specifies whether the storage auto grow for PostgreSQL Flexible Server is enabled? Defaults to false."
+  description = "Specifies whether the storage auto grow for PostgreSQL Flexible Server is enabled."
 }
 
 variable "trigger_password_reset" {

--- a/pgsql-flexible-server.tf
+++ b/pgsql-flexible-server.tf
@@ -122,6 +122,7 @@ resource "azurerm_postgresql_flexible_server" "pgsql_server" {
     ignore_changes = [
       zone,
       high_availability.0.standby_availability_zone,
+      storage_mb,
     ]
   }
 


### PR DESCRIPTION
## What changed

The PostgreSQL Flexible Server resource now ignores drift on `storage_mb` while still passing `pgsql_storage_mb` into the resource.

## Why

Azure can increase allocated storage automatically when auto-grow is enabled. If Terraform later compares that larger remote value with the original configured value, it can plan a storage reduction, and the AzureRM provider marks storage downgrades as replacements.

Terraform requires `lifecycle.ignore_changes` to be a static list, so it cannot be enabled only when `auto_grow_enabled` is true without splitting the server resource and risking state/address churn. Ignoring `storage_mb` unconditionally preserves creation-time sizing for existing callers while avoiding destructive shrink plans after Azure grows storage.

## Impact

`pgsql_storage_mb` is still used when the server is created. Later changes to `pgsql_storage_mb` will not be applied by Terraform; storage increases should be handled outside this module or by temporarily changing the lifecycle behavior.

## Validation

- `terraform fmt -check`
- `terraform validate` from `example`
- `git diff --check`
